### PR TITLE
fix: use colorModel instead of isUASTC for KTX2 format priority lookup

### DIFF
--- a/adapter/src/platforms/tiktok/minigame/engine/KTX2Loader.ts
+++ b/adapter/src/platforms/tiktok/minigame/engine/KTX2Loader.ts
@@ -3,7 +3,7 @@ exports.KTX2Loader = /*#__PURE__*/ function(Loader) {
     /** @internal */ KTX2Loader._parseBuffer = function _parseBuffer(buffer, engine, params) {
         var ktx2Container = new KTX2Container(buffer);
         var _params_priorityFormats;
-        var formatPriorities = (_params_priorityFormats = params == null ? void 0 : params.priorityFormats) != null ? _params_priorityFormats : KTX2Loader._priorityFormats[ktx2Container.isUASTC ? "uastc" : "etc1s"];
+        var formatPriorities = (_params_priorityFormats = params == null ? void 0 : params.priorityFormats) != null ? _params_priorityFormats : KTX2Loader._priorityFormats[ktx2Container.colorModel];
         var targetFormat = KTX2Loader._decideTargetFormat(engine, ktx2Container, formatPriorities);
         var binomialLLCWorker = KTX2Loader._getBinomialLLCTranscoder();
         var transcodeResultPromise = binomialLLCWorker.init().then(function() {

--- a/adapter/src/platforms/wechat/minigame/engine/KTX2Loader.ts
+++ b/adapter/src/platforms/wechat/minigame/engine/KTX2Loader.ts
@@ -3,7 +3,7 @@ exports.KTX2Loader = /*#__PURE__*/ function(Loader) {
     /** @internal */ KTX2Loader._parseBuffer = function _parseBuffer(buffer, engine, params) {
         var ktx2Container = new KTX2Container(buffer);
         var _params_priorityFormats;
-        var formatPriorities = (_params_priorityFormats = params == null ? void 0 : params.priorityFormats) != null ? _params_priorityFormats : KTX2Loader._priorityFormats[ktx2Container.isUASTC ? "uastc" : "etc1s"];
+        var formatPriorities = (_params_priorityFormats = params == null ? void 0 : params.priorityFormats) != null ? _params_priorityFormats : KTX2Loader._priorityFormats[ktx2Container.colorModel];
         var targetFormat = KTX2Loader._decideTargetFormat(engine, ktx2Container, formatPriorities);
         var binomialLLCWorker = KTX2Loader._getBinomialLLCTranscoder();
         var transcodeResultPromise = binomialLLCWorker.init().then(function() {


### PR DESCRIPTION
## Summary

- `KTX2Loader._parseBuffer` replacement used `ktx2Container.isUASTC ? "uastc" : "etc1s"` to look up `_priorityFormats`, but engine 1.6.4's `_priorityFormats` is keyed by `ColorModel` enum values (`163`, `166`, `167`), not string keys
- This key type mismatch causes `_detectSupportedFormat` to receive `undefined` as `priorityFormats`, crashing with `TypeError: Cannot read properties of undefined (reading 'length')`
- Fix: use `ktx2Container.colorModel` (numeric enum value) to match the engine's `_priorityFormats` key format

## Root Cause

The engine source (`KTX2Loader.ts`) uses:
```ts
KTX2Loader._priorityFormats[ktx2Container.colorModel]
```

But the platform-adapter replacement code used an older API:
```js
KTX2Loader._priorityFormats[ktx2Container.isUASTC ? "uastc" : "etc1s"]
```

`_priorityFormats` is initialized with `ColorModel` enum keys:
```js
_priorityFormats[ColorModel.ETC1S /* 163 */] = [...]
_priorityFormats[ColorModel.UASTC_LDR_4X4 /* 166 */] = [...]
```

String key `"uastc"` will never match numeric key `163`/`166`.

## Files Changed

- `adapter/src/platforms/tiktok/minigame/engine/KTX2Loader.ts`
- `adapter/src/platforms/wechat/minigame/engine/KTX2Loader.ts`

## Test plan

- [ ] Export a mini-game project with KTX2 textures from Galacean Editor
- [ ] Build with project-builder and verify no runtime crash on `_detectSupportedFormat`
- [ ] Verify KTX2 textures render correctly in both TikTok and WeChat mini-game environments